### PR TITLE
DRAFT: Scribble support thus far

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -680,6 +680,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   [_textInputChannel.get() invokeMethod:@"TextInputClient.showToolbar" arguments:@[@(client)]];
 }
 
+- (void)focusElement:(UIScribbleElementIdentifier)elementIdentifier atPoint:(CGPoint)referencePoint {
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.focusElement" arguments:@[elementIdentifier, @(referencePoint.x), @(referencePoint.y)]];
+}
+
 #pragma mark - Screenshot Delegate
 
 - (flutter::Rasterizer::Screenshot)takeScreenshot:(flutter::Rasterizer::ScreenshotType)type

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -448,6 +448,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     [_textInputChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
       [textInputPlugin handleMethodCall:call result:result];
     }];
+    textInputPlugin.channel = _textInputChannel.get();
   }
 }
 
@@ -672,6 +673,18 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                   withClient:(int)client {
   [_textInputChannel.get() invokeMethod:@"TextInputClient.showAutocorrectionPromptRect"
                               arguments:@[ @(client), @(start), @(end) ]];
+}
+
+- (FlutterResult)firstRectForRange:(int)client start:(NSUInteger)start
+                                         end:(NSUInteger)end {
+  __block id _Nullable result = nil;
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.firstRectForRange"
+                              arguments:@[ @(client), @(start), @(end) ]
+                              result:^(id _Nullable _result) {
+                                NSLog(@"TextInputClient.firstRectForRange result:%@", _result);
+                                result = _result;
+                              }];
+  return result;
 }
 
 #pragma mark - Screenshot Delegate

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -680,8 +680,8 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   [_textInputChannel.get() invokeMethod:@"TextInputClient.showToolbar" arguments:@[@(client)]];
 }
 
-- (void)focusElement:(UIScribbleElementIdentifier)elementIdentifier atPoint:(CGPoint)referencePoint {
-  [_textInputChannel.get() invokeMethod:@"TextInputClient.focusElement" arguments:@[elementIdentifier, @(referencePoint.x), @(referencePoint.y)]];
+- (void)focusElement:(UIScribbleElementIdentifier)elementIdentifier atPoint:(CGPoint)referencePoint result:(id)callback {
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.focusElement" arguments:@[elementIdentifier, @(referencePoint.x), @(referencePoint.y)] result:callback];
 }
 
 #pragma mark - Screenshot Delegate

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -248,6 +248,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.iosPlatformView->SetOwnerViewController(_viewController);
   [self maybeSetupPlatformViewChannels];
   _textInputPlugin.get().viewController = [self viewController];
+  [_textInputPlugin.get() setupIndirectScribbleInteraction];
 
   if (viewController) {
     __block FlutterEngine* blockSelf = self;
@@ -427,6 +428,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _textInputPlugin.reset([[FlutterTextInputPlugin alloc] init]);
   _textInputPlugin.get().textInputDelegate = self;
   _textInputPlugin.get().viewController = [self viewController];
+  [_textInputPlugin.get() setupIndirectScribbleInteraction];
 
   _platformPlugin.reset([[FlutterPlatformPlugin alloc] initWithEngine:[self getWeakPtr]]);
 }
@@ -682,6 +684,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
 - (void)focusElement:(UIScribbleElementIdentifier)elementIdentifier atPoint:(CGPoint)referencePoint result:(id)callback {
   [_textInputChannel.get() invokeMethod:@"TextInputClient.focusElement" arguments:@[elementIdentifier, @(referencePoint.x), @(referencePoint.y)] result:callback];
+}
+
+- (void)requestElementsInRect:(CGRect)rect result:(id)callback {
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.requestElementsInRect" arguments:@[@(rect.origin.x), @(rect.origin.y), @(rect.size.width), @(rect.size.height)] result:callback];
 }
 
 #pragma mark - Screenshot Delegate

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -247,6 +247,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       viewController ? [viewController getWeakPtr] : fml::WeakPtr<FlutterViewController>();
   self.iosPlatformView->SetOwnerViewController(_viewController);
   [self maybeSetupPlatformViewChannels];
+  _textInputPlugin.get().viewController = [self viewController];
 
   if (viewController) {
     __block FlutterEngine* blockSelf = self;
@@ -425,6 +426,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
   _textInputPlugin.reset([[FlutterTextInputPlugin alloc] init]);
   _textInputPlugin.get().textInputDelegate = self;
+  _textInputPlugin.get().viewController = [self viewController];
 
   _platformPlugin.reset([[FlutterPlatformPlugin alloc] initWithEngine:[self getWeakPtr]]);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -448,7 +448,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     [_textInputChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
       [textInputPlugin handleMethodCall:call result:result];
     }];
-    textInputPlugin.channel = _textInputChannel.get();
   }
 }
 
@@ -673,18 +672,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                   withClient:(int)client {
   [_textInputChannel.get() invokeMethod:@"TextInputClient.showAutocorrectionPromptRect"
                               arguments:@[ @(client), @(start), @(end) ]];
-}
-
-- (FlutterResult)firstRectForRange:(int)client start:(NSUInteger)start
-                                         end:(NSUInteger)end {
-  __block id _Nullable result = nil;
-  [_textInputChannel.get() invokeMethod:@"TextInputClient.firstRectForRange"
-                              arguments:@[ @(client), @(start), @(end) ]
-                              result:^(id _Nullable _result) {
-                                NSLog(@"TextInputClient.firstRectForRange result:%@", _result);
-                                result = _result;
-                              }];
-  return result;
 }
 
 #pragma mark - Screenshot Delegate

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -676,6 +676,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                               arguments:@[ @(client), @(start), @(end) ]];
 }
 
+- (void)showToolbar:(int)client {
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.showToolbar" arguments:@[@(client)]];
+}
+
 #pragma mark - Screenshot Delegate
 
 - (flutter::Rasterizer::Screenshot)takeScreenshot:(flutter::Rasterizer::ScreenshotType)type

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 - (void)focusElement:(UIScribbleElementIdentifier)elementIdentifier
              atPoint:(CGPoint)referencePoint
               result:(id)callback;
+- (void)requestElementsInRect:(CGRect)rect result:(id)callback;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -39,7 +39,9 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
                                          end:(NSUInteger)end
                                   withClient:(int)client;
 - (void)showToolbar:(int)client;
-- (void)focusElement:(UIScribbleElementIdentifier)elementIdentifier atPoint:(CGPoint)referencePoint;
+- (void)focusElement:(UIScribbleElementIdentifier)elementIdentifier
+             atPoint:(CGPoint)referencePoint
+              result:(id)callback;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
                                          end:(NSUInteger)end
                                   withClient:(int)client;
 - (void)showToolbar:(int)client;
+- (void)focusElement:(UIScribbleElementIdentifier)elementIdentifier atPoint:(CGPoint)referencePoint;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -38,7 +38,6 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 - (void)showAutocorrectionPromptRectForStart:(NSUInteger)start
                                          end:(NSUInteger)end
                                   withClient:(int)client;
-- (FlutterResult)firstRectForRange:(int)client start:(NSUInteger)start end:(NSUInteger)end;
 @end
 
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTDELEGATE_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 - (void)showAutocorrectionPromptRectForStart:(NSUInteger)start
                                          end:(NSUInteger)end
                                   withClient:(int)client;
+- (FlutterResult)firstRectForRange:(int)client start:(NSUInteger)start end:(NSUInteger)end;
 @end
 
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTDELEGATE_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -38,6 +38,8 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 - (void)showAutocorrectionPromptRectForStart:(NSUInteger)start
                                          end:(NSUInteger)end
                                   withClient:(int)client;
+- (void)showToolbar:(int)client;
+
 @end
 
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTDELEGATE_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -142,6 +142,8 @@ FLUTTER_EXPORT
 
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
 @property(nonatomic, assign) FlutterViewController* viewController;
+@property(nonatomic) BOOL scribbleFocusing;
+@property(nonatomic) BOOL scribbleFocused;
 
 @end
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTPLUGIN_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -57,9 +57,6 @@
  * correct element
  */
 - (void)setupIndirectScribbleInteraction;
-- (void)registerScribbleElement:(UIScribbleElementIdentifier)elementIdentifier
-                       withRect:(CGRect)rect;
-- (void)deregisterScribbleElement:(UIScribbleElementIdentifier)elementIdentifier;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -23,8 +23,6 @@
  */
 - (UIView<UITextInput>*)textInputView;
 
-@property(nonatomic, assign) FlutterMethodChannel* channel;
-
 @end
 
 /** An indexed position in the buffer of a Flutter text editing widget. */
@@ -54,8 +52,17 @@
 @property(nonatomic, readonly) BOOL containsEnd;
 @property(nonatomic, readonly) BOOL isVertical;
 
-+ (instancetype)selectionRectWithRect:(CGRect)rect;
-- (instancetype)initWithRect:(CGRect)rect;
++ (instancetype)selectionRectWithRectAndInfo:(CGRect)rect
+                            writingDirection:(NSWritingDirection)writingDirection
+                               containsStart:(BOOL)containsStart
+                                 containsEnd:(BOOL)containsEnd
+                                  isVertical:(BOOL)isVertical;
+
+- (instancetype)initWithRectAndInfo:(CGRect)rect
+                   writingDirection:(NSWritingDirection)writingDirection
+                      containsStart:(BOOL)containsStart
+                        containsEnd:(BOOL)containsEnd
+                         isVertical:(BOOL)isVertical;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -9,10 +9,12 @@
 
 #include "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 
 @interface FlutterTextInputPlugin : NSObject
 
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
+@property(nonatomic, assign) FlutterViewController* viewController;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 
 /**
@@ -69,7 +71,7 @@
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 FLUTTER_EXPORT
 #endif
-@interface FlutterTextInputView : UIView <UITextInput>
+@interface FlutterTextInputView : UIView <UITextInput, UIScribbleInteractionDelegate>
 
 // UITextInput
 @property(nonatomic, readonly) NSMutableString* text;
@@ -92,7 +94,18 @@ FLUTTER_EXPORT
 @property(nonatomic) UITextSmartDashesType smartDashesType API_AVAILABLE(ios(11.0));
 @property(nonatomic, copy) UITextContentType textContentType API_AVAILABLE(ios(10.0));
 
+// UIScribbleInteractionDelegate
+- (void)scribbleInteractionWillBeginWriting:(UIScribbleInteraction*)interaction
+    API_AVAILABLE(ios(14.0));
+- (void)scribbleInteractionDidFinishWriting:(UIScribbleInteraction*)interaction
+    API_AVAILABLE(ios(14.0));
+- (BOOL)scribbleInteraction:(UIScribbleInteraction*)interaction
+      shouldBeginAtLocation:(CGPoint)location API_AVAILABLE(ios(14.0));
+- (BOOL)scribbleInteractionShouldDelayFocus:(UIScribbleInteraction*)interaction
+    API_AVAILABLE(ios(14.0));
+
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
+@property(nonatomic, assign) FlutterViewController* viewController;
 
 @end
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTPLUGIN_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -25,6 +25,35 @@
  */
 - (UIView<UITextInput>*)textInputView;
 
+- (void)setupIndirectScribbleInteraction;
+
+// UIIndirectScribbleInteractionDelegate
+- (BOOL)indirectScribbleInteraction:(UIIndirectScribbleInteraction*)interaction
+                   isElementFocused:(UIScribbleElementIdentifier)elementIdentifier
+    API_AVAILABLE(ios(14.0));
+- (void)indirectScribbleInteraction:(UIIndirectScribbleInteraction*)interaction
+               focusElementIfNeeded:(UIScribbleElementIdentifier)elementIdentifier
+                     referencePoint:(CGPoint)focusReferencePoint
+                         completion:(void (^)(UIResponder<UITextInput>* focusedInput))completion
+    API_AVAILABLE(ios(14.0));
+- (BOOL)indirectScribbleInteraction:(UIIndirectScribbleInteraction*)interaction
+         shouldDelayFocusForElement:(UIScribbleElementIdentifier)elementIdentifier
+    API_AVAILABLE(ios(14.0));
+- (void)indirectScribbleInteraction:(UIIndirectScribbleInteraction*)interaction
+          willBeginWritingInElement:(UIScribbleElementIdentifier)elementIdentifier
+    API_AVAILABLE(ios(14.0));
+- (void)indirectScribbleInteraction:(UIIndirectScribbleInteraction*)interaction
+          didFinishWritingInElement:(UIScribbleElementIdentifier)elementIdentifier
+    API_AVAILABLE(ios(14.0));
+- (CGRect)indirectScribbleInteraction:(UIIndirectScribbleInteraction*)interaction
+                      frameForElement:(UIScribbleElementIdentifier)elementIdentifier
+    API_AVAILABLE(ios(14.0));
+- (void)indirectScribbleInteraction:(UIIndirectScribbleInteraction*)interaction
+              requestElementsInRect:(CGRect)rect
+                         completion:
+                             (void (^)(NSArray<UIScribbleElementIdentifier>* elements))completion
+    API_AVAILABLE(ios(14.0));
+
 @end
 
 /** An indexed position in the buffer of a Flutter text editing widget. */

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -25,8 +25,6 @@
  */
 - (UIView<UITextInput>*)textInputView;
 
-- (void)setupIndirectScribbleInteraction;
-
 // UIIndirectScribbleInteractionDelegate
 - (BOOL)indirectScribbleInteraction:(UIIndirectScribbleInteraction*)interaction
                    isElementFocused:(UIScribbleElementIdentifier)elementIdentifier
@@ -53,6 +51,15 @@
                          completion:
                              (void (^)(NSArray<UIScribbleElementIdentifier>* elements))completion
     API_AVAILABLE(ios(14.0));
+
+/**
+ * These are used by the UIIndirectScribbleInteractionDelegate methods to handle focusing on the
+ * correct element
+ */
+- (void)setupIndirectScribbleInteraction;
+- (void)registerScribbleElement:(UIScribbleElementIdentifier)elementIdentifier
+                       withRect:(CGRect)rect;
+- (void)deregisterScribbleElement:(UIScribbleElementIdentifier)elementIdentifier;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -23,6 +23,8 @@
  */
 - (UIView<UITextInput>*)textInputView;
 
+@property(nonatomic, assign) FlutterMethodChannel* channel;
+
 @end
 
 /** An indexed position in the buffer of a Flutter text editing widget. */
@@ -41,6 +43,19 @@
 @property(nonatomic, readonly) NSRange range;
 
 + (instancetype)rangeWithNSRange:(NSRange)range;
+
+@end
+
+@interface FlutterTextSelectionRect : UITextSelectionRect
+
+@property(nonatomic, readonly) CGRect rect;
+@property(nonatomic, readonly) NSWritingDirection writingDirection;
+@property(nonatomic, readonly) BOOL containsStart;
+@property(nonatomic, readonly) BOOL containsEnd;
+@property(nonatomic, readonly) BOOL isVertical;
+
++ (instancetype)selectionRectWithRect:(CGRect)rect;
+- (instancetype)initWithRect:(CGRect)rect;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1019,12 +1019,13 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 
   NSUInteger start = ((FlutterTextPosition*)range.start).index;
   NSUInteger end = ((FlutterTextPosition*)range.end).index;
-  [_textInputDelegate showAutocorrectionPromptRectForStart:start
-                                                       end:end
-                                                withClient:_textInputClient];
+  if (!_scribbleInProgress) {
+    [_textInputDelegate showAutocorrectionPromptRectForStart:start
+                                                        end:end
+                                                  withClient:_textInputClient];
+  }
 
   NSLog(@"[scribble] firstRectForRange %@ - %@", @(start), @(end));
-//  return CGRectMake(0, 0, start * 15, 19); // deleting does not work at all without this
     NSUInteger first = start;
     if (end < start) {
         first = end;
@@ -1033,6 +1034,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
       NSLog(@"[scribble] firstRectForRange -> %f, %f, %f, %f", [_selectionRects[first][0] floatValue], [_selectionRects[first][1] floatValue], [_selectionRects[first][2] floatValue], [_selectionRects[first][3] floatValue]);
     return CGRectMake([_selectionRects[first][0] floatValue], [_selectionRects[first][1] floatValue], [_selectionRects[first][2] floatValue], [_selectionRects[first][3] floatValue]);
   }
+  NSLog(@"[scribble] firstRectForRange -> CGRectZero");
   // TODO(cbracken) Implement.
   return CGRectZero;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -730,6 +730,12 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 - (void)setSelectedTextRange:(UITextRange*)selectedTextRange {
   [self setSelectedTextRangeLocal:selectedTextRange];
   [self updateEditingState];
+  if (_scribbleInProgress) {
+    FlutterTextRange* flutterTextRange = (FlutterTextRange*)selectedTextRange;
+    if (flutterTextRange.range.length > 0) {
+      [_textInputDelegate showToolbar:_textInputClient];
+    }
+  }
 }
 
 - (id)insertDictationResultPlaceholder {
@@ -1163,6 +1169,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
     @"composingBase" : @(composingBase),
     @"composingExtent" : @(composingExtent),
     @"text" : [NSString stringWithString:self.text],
+    @"scribbleInProgress" : @(_scribbleInProgress),
   };
 
   if (_textInputClient == 0 && _autofillId != nil) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -600,33 +600,24 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   return needsEditingStateUpdate;
 }
 
-// Problem: tapping doesn't change the cursor location. have to make a small drag with the pencil.
-// Tried so far:
-// - not being the first responder
-// - forwarding the following selectors to the superview
-
+// Forward touches to the viewController to allow tapping inside the UITextField as normal
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
-    NSLog(@"[scribble][cursor] touchesBegan");
     [self.viewController touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
-    NSLog(@"[scribble][cursor] touchesMoved");
     [self.viewController touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-    NSLog(@"[scribble][cursor] touchesEnded");
     [self.viewController touchesEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
-    NSLog(@"[scribble][cursor] touchesCancelled");
     [self.viewController touchesCancelled:touches withEvent:event];
 }
 
 - (void)touchesEstimatedPropertiesUpdated:(NSSet *)touches {
-    NSLog(@"[scribble][cursor] touchesEstimatedPropertiesUpdated");
     [self.viewController touchesEstimatedPropertiesUpdated:touches];
 }
 
@@ -758,7 +749,6 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   NSAssert(textRange.location != NSNotFound, @"Expected a valid text range.");
-  NSLog(@"[scribble] textInRange %@ - %@ = %@", @(textRange.location), @(textRange.length), [self.text substringWithRange:textRange]);
   return [self.text substringWithRange:textRange];
 }
 
@@ -1057,10 +1047,8 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   return CGRectZero;
 }
 
-// TODO(jcouch): cursor not moving around correctly when tapping
 - (UITextPosition*)closestPositionToPoint:(CGPoint)point {
   // TODO(cbracken) Implement.
-  // Maybe janky without these?
   NSLog(@"[scribble] closestPositionToPoint (%@, %@)", @(point.x), @(point.y));
 
   NSUInteger _closestIndex = 0;
@@ -1101,7 +1089,6 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   return rects;
 }
 
-// TODO(jcouch): IMPLEMENT?!?
 - (UITextPosition*)closestPositionToPoint:(CGPoint)point withinRange:(UITextRange*)range {
   // TODO(cbracken) Implement.
   NSUInteger start = ((FlutterTextPosition*)range.start).index;
@@ -1126,27 +1113,23 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 
 - (UITextRange*)characterRangeAtPoint:(CGPoint)point {
   // TODO(cbracken) Implement.
-  NSLog(@"[scribble] characterRangeAtPoint (%@, %@)", @(point.x), @(point.y));
   NSUInteger currentIndex = ((FlutterTextPosition*)_selectedTextRange.start).index;
   return [FlutterTextRange rangeWithNSRange:fml::RangeForCharacterAtIndex(self.text, currentIndex)];
 }
 
 - (void)beginFloatingCursorAtPoint:(CGPoint)point {
-  NSLog(@"[scribble][cursor] beginFloatingCursorAtPoint (%@, %@)", @(point.x), @(point.y));
   [_textInputDelegate updateFloatingCursor:FlutterFloatingCursorDragStateStart
                                 withClient:_textInputClient
                               withPosition:@{@"X" : @(point.x), @"Y" : @(point.y)}];
 }
 
 - (void)updateFloatingCursorAtPoint:(CGPoint)point {
-  NSLog(@"[scribble][cursor] updateFloatingCursorAtPoint (%@, %@)", @(point.x), @(point.y));
   [_textInputDelegate updateFloatingCursor:FlutterFloatingCursorDragStateUpdate
                                 withClient:_textInputClient
                               withPosition:@{@"X" : @(point.x), @"Y" : @(point.y)}];
 }
 
 - (void)endFloatingCursor {
-  NSLog(@"[scribble][cursor] endFloatingCursor");
   [_textInputDelegate updateFloatingCursor:FlutterFloatingCursorDragStateEnd
                                 withClient:_textInputClient
                               withPosition:@{@"X" : @(0), @"Y" : @(0)}];
@@ -1316,6 +1299,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 }
 
 - (void)setSizeAndTransform:(NSDictionary*)sizeAndTransform {
+  // TODO: only do this on iPadOS?
   // This seems necessary to set up where the scribble interactable element will be
   _activeView.frame = CGRectMake([sizeAndTransform[@"transform"][12] intValue], [sizeAndTransform[@"transform"][13] intValue], [sizeAndTransform[@"width"] intValue], [sizeAndTransform[@"height"] intValue]);
 }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -331,7 +331,6 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
 }
 
 - (void)setMarkedText:(NSString*)markedText selectedRange:(NSRange)selectedRange {
-  NSLog(@"[scribble] setMarkedText (AccessibilityTextEntry)");
   [[self textInputSurrogate] setMarkedText:markedText selectedRange:selectedRange];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -331,6 +331,7 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
 }
 
 - (void)setMarkedText:(NSString*)markedText selectedRange:(NSRange)selectedRange {
+  NSLog(@"[scribble] setMarkedText (AccessibilityTextEntry)");
   [[self textInputSurrogate] setMarkedText:markedText selectedRange:selectedRange];
 }
 


### PR DESCRIPTION
## Description

Adds scribble support by receiving the list of selection boxes from the flutter TextInputConnection channel (see  https://github.com/twinsunllc/flutter/commit/7b39621922fef973dca7dce8d9b4f7d8d2408334). This still has the following issues:

* The FlutterTextInput having a size seems to "consume" tap events so that the cursor can't be moved around with non-scribble methods (instead of being able to tap with the pencil or a finger, you have to draw a short line with the pencil similar to how you can make a line through a word to select it). I tried forwarding the touchesBegan, etc selectors to the superview, but that didn't help.
* There do seem to be some issues still remaining around managing the selected text. Somehow, I keep ending up with the last character selected in addition to whatever actual selection is there.
* Once text is selected, making any marks will (usually) replace that text rather than making a new selection. I suspect that is related to the previous item. Possibly some kind of issue keeping the FlutterTextInput selection synced up with the flutter side?
* Finally, scribble only works once the input is focused, which is not how it works natively

## Related Issues

* https://github.com/flutter/flutter/issues/61278
